### PR TITLE
clua_pushcallback has been added to allow definining metamethods with Go...

### DIFF
--- a/lua/c-golua.c
+++ b/lua/c-golua.c
@@ -104,6 +104,18 @@ void clua_pushgofunction(lua_State* L, unsigned int fid)
 	lua_setmetatable(L, -2);
 }
 
+static int callback_c (lua_State* L)
+{
+	int fid = clua_togofunction(L,lua_upvalueindex(1));
+	GoInterface *gi = clua_getgostate(L);
+	return golua_callgofunction(*gi,fid);
+}
+
+void clua_pushcallback(lua_State* L)
+{
+	lua_pushcclosure(L,callback_c,1);
+}
+
 void clua_pushgostruct(lua_State* L, unsigned int iid)
 {
 	unsigned int* iidptr = (unsigned int *)lua_newuserdata(L, sizeof(unsigned int));

--- a/lua/golua.h
+++ b/lua/golua.h
@@ -7,6 +7,7 @@ void clua_initstate(lua_State* L);
 
 unsigned int clua_togofunction(lua_State* L, int index);
 unsigned int clua_togostruct(lua_State *L, int index);
+void clua_pushcallback(lua_State* L);
 void clua_pushgofunction(lua_State* L, unsigned int fid);
 void clua_pushgostruct(lua_State *L, unsigned int fid);
 void clua_setgostate(lua_State* L, GoInterface gostate);

--- a/lua/lua.go
+++ b/lua/lua.go
@@ -91,6 +91,12 @@ func (L *State) PushGoFunction(f LuaGoFunction) {
 	C.clua_pushgofunction(L.s, C.uint(fid))
 }
 
+// Like lua_pushcclosure pushes a new Go closure onto the stack
+func (L *State) PushGoCallback(f LuaGoFunction) {
+	L.PushGoFunction(f) // leaves Go function userdata on stack
+	C.clua_pushcallback(L.s)
+}
+
 // Pushes a Go struct onto the stack as user data.
 //
 // The user data will be rigged so that lua code can access and change to public members of simple types directly


### PR DESCRIPTION
clua_pushcallback has been added to allow definining metamethods with Go functions.

This adds the ability to push Go functions as C closures. It's code hand patched from @stevedonovan's golua repo.  Specifically: https://github.com/stevedonovan/golua/commit/3a27ba88ab6637e70ae243ab29aa768e1734f697 without the changes to GoInterface.

His [luar](https://github.com/stevedonovan/luar) project, which uses golua, then only needs small changes to become compatible with your golua fork. 
