### PR TITLE
Added ToBytes and PushBytes methods.  Updated struct metamethod reflection to use them.

### DIFF
--- a/lua/lua.go
+++ b/lua/lua.go
@@ -385,6 +385,10 @@ func (L *State) PushString(str string) {
 	C.lua_pushlstring(L.s, Cstr, C.size_t(len(str)))
 }
 
+func (L *State) PushBytes(b []byte) {
+	C.lua_pushlstring(L.s, (*C.char)(unsafe.Pointer(&b[0])), C.size_t(len(b)))
+}
+
 // lua_pushinteger
 func (L *State) PushInteger(n int64) {
 	C.lua_pushinteger(L.s, C.lua_Integer(n))
@@ -534,6 +538,12 @@ func (L *State) ToString(index int) string {
 	var size C.size_t
 	r := C.lua_tolstring(L.s, C.int(index), &size)
 	return C.GoStringN(r, C.int(size))
+}
+
+func (L *State) ToBytes(index int) []byte {
+	var size C.size_t
+	b := C.lua_tolstring(L.s, C.int(index), &size)
+	return C.GoBytes(unsafe.Pointer(b), C.int(size))
 }
 
 // lua_tointeger


### PR DESCRIPTION
This commit supports interacting with byte slice struct members as strings in Lua.

For example:

```go
package main

import "fmt"
import "github.com/aarzilli/golua/lua"

type JimJam struct {
   Data []byte
}

func main() {

   L := lua.NewState()
   defer L.Close()
   L.OpenLibs()

   L.DoString(`
function foo (arg)
   print("Data is: " .. arg.Data)
   arg.Data = "abcd"
   print("Data is now: " .. arg.Data)
end
`)

   jj := JimJam{ Data: []byte("foobar") }

   fmt.Println("pre-lua Data is: ", jj.Data)
   L.GetField(lua.LUA_GLOBALSINDEX, "foo")
   L.PushGoStruct(&jj)
   L.Call(1, 0)
   fmt.Println("post-lua Data is: ", jj.Data)
}
```

Produces the following output:

```
pre-lua Data is:  [102 111 111 98 97 114]
Data is: foobar
Data is now: abcd
post-lua Data is:  [97 98 99 100]
```