### PR TITLE
fix new state crash

### DIFF
--- a/lua/lauxlib.go
+++ b/lua/lauxlib.go
@@ -166,6 +166,9 @@ func (L *State) NewMetaTable(tname string) bool {
 // luaL_newstate
 func NewState() *State {
 	ls := (C.luaL_newstate())
+	if ls == nil {
+		return nil
+	}
 	L := newState(ls)
 	return L
 }


### PR DESCRIPTION
`golua` will crash when `C.luaL_newstate` failed, because LuaJIT has [hard limited to 1G memory space](https://stackoverflow.com/questions/35155444/why-is-luajits-memory-limited-to-1-2-gb-on-64-bit-platforms).

```go
package main

import (
	"github.com/aarzilli/golua/lua"
	"gopkg.in/cheggaaa/pb.v1"
)

func main() {
	count := 100000
	bar := pb.StartNew(count)
	for i := 0; i < count; i++ {
		bar.Increment()
		if L := lua.NewState(); L != nil {
			L.OpenLibs()
			defer L.Close()
		} else {
			bar.FinishPrint("new state failed")
			break
		}
	}
}

```

>fatal error: unexpected signal during runtime execution
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x7fff04c4fb80]
>
>runtime stack:
runtime.throw(0x4106c4b, 0x2a)
	/usr/local/opt/go/libexec/src/runtime/panic.go:596 +0x95
runtime.sigpanic()
	/usr/local/opt/go/libexec/src/runtime/signal_unix.go:274 +0x2db
>
>goroutine 1 [syscall, locked to thread]:
runtime.cgocall(0x40c52b0, 0xc420474e80, 0x41069de)
	/usr/local/opt/go/libexec/src/runtime/cgocall.go:131 +0xe2 fp=0xc420474e40 sp=0xc420474e00
github.com/aarzilli/golua/lua._Cfunc_clua_setgostate(0x0, 0xc4206c8580)
	github.com/aarzilli/golua/lua/_obj/_cgo_gotypes.go:431 +0x45 fp=0xc420474e80 sp=0xc420474e40
github.com/aarzilli/golua/lua.newState.func1(0x0, 0xc4206c8580)
	/Users/flier/gocode/src/github.com/aarzilli/golua/lua/lua.go:39 +0x6a fp=0xc420474eb8 sp=0xc420474e80
github.com/aarzilli/golua/lua.newState(0x0, 0x3d59)
	/Users/flier/gocode/src/github.com/aarzilli/golua/lua/lua.go:39 +0x154 fp=0xc420474f30 sp=0xc420474eb8
github.com/aarzilli/golua/lua.NewState(0xc4200a4280)
	/Users/flier/gocode/src/github.com/aarzilli/golua/lua/lauxlib.go:169 +0x2f fp=0xc420474f50 sp=0xc420474f30
main.main()
	/Users/flier/NexusGuard/Source/nxgw-engine/luavm.go:13 +0x56 fp=0xc420474f88 sp=0xc420474f50
runtime.main()