### PR TITLE
Attach last error to the state

### DIFF
--- a/lua/c-golua.c
+++ b/lua/c-golua.c
@@ -209,10 +209,10 @@ int interface_newindex_callback(lua_State *L)
 	}
 }
 
-int panic_msghandler(lua_State *L)
+int err_msghandler(lua_State *L)
 {
 	size_t gostateindex = clua_getgostate(L);
-	go_panic_msghandler(gostateindex, (char *)lua_tolstring(L, -1, NULL));
+	go_err_msghandler(gostateindex, (char *)lua_tolstring(L, -1, NULL));
 	return 0;
 }
 
@@ -262,7 +262,7 @@ void clua_initstate(lua_State* L)
 	lua_pushcfunction(L, &interface_newindex_callback);
 	lua_settable(L, -3);
 
-	lua_register(L, GOLUA_DEFAULT_MSGHANDLER, &panic_msghandler);
+	lua_register(L, GOLUA_DEFAULT_MSGHANDLER, &err_msghandler);
 	lua_pop(L, 1);
 }
 

--- a/lua/lua.go
+++ b/lua/lua.go
@@ -34,7 +34,7 @@ type LuaStackEntry struct {
 }
 
 func newState(L *C.lua_State) *State {
-	newstate := &State{L, 0, make([]interface{}, 0, 8), make([]uint, 0, 8)}
+	newstate := &State{L, 0, make([]interface{}, 0, 8), make([]uint, 0, 8), nil}
 	registerGoState(newstate)
 	C.clua_setgostate(L, C.size_t(newstate.Index))
 	C.clua_initstate(L)
@@ -77,9 +77,9 @@ func (L *State) register(f interface{}) uint {
 		index = uint(len(L.registry))
 		//reallocate backing array if necessary
 		if index+1 > uint(cap(L.registry)) {
-			newcap := cap(L.registry)*2
+			newcap := cap(L.registry) * 2
 			if index+1 > uint(newcap) {
-				newcap = int(index+1)
+				newcap = int(index + 1)
 			}
 			newSlice := make([]interface{}, index, newcap)
 			copy(newSlice, L.registry)
@@ -204,7 +204,8 @@ func (L *State) callEx(nargs, nresults int, catch bool) (err error) {
 	r := L.pcall(nargs, nresults, erridx)
 	L.Remove(erridx)
 	if r != 0 {
-		err = &LuaError{r, L.ToString(-1), L.StackTrace()}
+		err = L.lastErr
+		L.lastErr = nil
 		if !catch {
 			panic(err)
 		}
@@ -353,7 +354,7 @@ func (L *State) NewThread() *State {
 	//TODO: should have same lists as parent
 	//		but may complicate gc
 	s := C.lua_newthread(L.s)
-	return &State{s, 0, nil, nil}
+	return &State{s, 0, nil, nil, nil}
 }
 
 // lua_next


### PR DESCRIPTION
This fixes https://github.com/aarzilli/golua/issues/24 by adding a `lastErr` attribute to the state, we can track the error that was received by the error handler while still allowing the error handler function to return. Since the function returns, the stack is properly cleaned up and both the `"C stack overflow"` and `"error in error handling"` errors go away.

This fix also improves performance:

Before:

```
BenchmarkFix-8          10000        131910 ns/op       45529 B/op         897 allocs/op
PASS
ok      github.com/andrewhare/tmp    1.340s
```

After:

```
BenchmarkFix-8         300000          4258 ns/op         552 B/op          14 allocs/op
PASS
ok      github.com/andrewhare/tmp    1.348s
```

Running the following benchmark:

```go
package main

import (
    "testing"

    "github.com/andrewhare/golua/lua"
)

var script = `
function doit()
    x[1] = 2
end
`

func BenchmarkFix(b *testing.B) {
    L := lua.NewState()
    L.OpenLibs()
    if err := L.DoString(script); err != nil {
        panic(err)
    }
    for n := 0; n < b.N; n++ {
        top := L.GetTop()
        L.GetGlobal("doit")
        err := L.Call(0, lua.LUA_MULTRET)
        if err == nil {
            panic("should have error")
        }
        L.SetTop(top)
    }
}
```