### PR TITLE
Fix vendoring of package using go mod vendor

### DIFF
--- a/lua/dummy.go
+++ b/lua/dummy.go
@@ -1,0 +1,18 @@
+// +build dummy
+
+// This file is part of a workaround for `go mod vendor` which won't
+// vendor C files if there are no Go files in the same directory.
+// This prevents the C header files in lua/ from being vendored.
+//
+// This Go file imports the lua package where there is another
+// dummy.go file which is the second part of this workaround.
+//
+// These two files combined make it so `go mod vendor` behaves correctly.
+//
+// See this issue for reference: https://github.com/golang/go/issues/26366
+
+package lua
+
+import (
+	_ "github.com/aarzilli/golua/lua/lua"
+)

--- a/lua/lua/dummy.go
+++ b/lua/lua/dummy.go
@@ -1,0 +1,7 @@
+// +build dummy
+
+// Package lua contains only a C header files.
+//
+// This Go file is part of a workaround for `go mod vendor`.
+// Please see the file dummy.go in the parent directory for more information.
+package lua


### PR DESCRIPTION
A directory with only C files will not be vendored by go mod vendor,
see this issue: https://github.com/golang/go/issues/26366,
specifically, Russ Cox's response
https://github.com/golang/go/issues/26366#issuecomment-405683150.

Because of this, when vendoring github.com/aarzilli/golua with go mod
vendor, the C header files under github.com/aarzilli/golua/lua/lua are
not vendored.  This commits adds a workaround to this issue by adding
dummy Go files which makes go mod behave correctly.  This workaround
was based on a similar one found here:
https://github.com/crawshaw/sqlite/pull/88.