### PR TITLE
Rename errno because it's a reserved global variable

### DIFF
--- a/lua/golua_c_lua51.go
+++ b/lua/golua_c_lua51.go
@@ -41,10 +41,10 @@ int load_chunk(lua_State *L, char *b, int size, const char* chunk_name) {
 	chunk ck;
 	ck.buffer = b;
 	ck.size = size;
-	int errno;
-	errno = lua_load(L, reader, &ck, chunk_name);
-	if (errno != 0) {
-		return luaL_error(L, "unable to load chunk, errno: %d", errno);
+	int err;
+	err = lua_load(L, reader, &ck, chunk_name);
+	if (err != 0) {
+		return luaL_error(L, "unable to load chunk, err: %d", err);
 	}
 	return 0;
 }
@@ -97,10 +97,10 @@ int dump_chunk (lua_State *L) {
 	luaL_checktype(L, -1, LUA_TFUNCTION);
 	lua_settop(L, -1);
 	luaL_buffinit(L,&b);
-	int errno;
-	errno = lua_dump(L, writer, &b);
-	if (errno != 0){
-	return luaL_error(L, "unable to dump given function, errno:%d", errno);
+	int err;
+	err = lua_dump(L, writer, &b);
+	if (err != 0){
+	return luaL_error(L, "unable to dump given function, err:%d", err);
 	}
 	luaL_pushresult(&b);
 	return 0;
@@ -205,5 +205,5 @@ func (L *State) RawSeti(index int, n int) {
 
 // lua_gc
 func (L *State) GC(what, data int) int {
-    return int(C.lua_gc(L.s, C.int(what), C.int(data)))
+	return int(C.lua_gc(L.s, C.int(what), C.int(data)))
 }

--- a/lua/golua_c_lua52.go
+++ b/lua/golua_c_lua52.go
@@ -41,10 +41,10 @@ int load_chunk(lua_State *L, char *b, int size, const char* chunk_name) {
 	chunk ck;
 	ck.buffer = b;
 	ck.size = size;
-	int errno;
-	errno = lua_load(L, reader, &ck, chunk_name, NULL);
-	if (errno != 0) {
-		return luaL_error(L, "unable to load chunk, errno: %d", errno);
+	int err;
+	err = lua_load(L, reader, &ck, chunk_name, NULL);
+	if (err != 0) {
+		return luaL_error(L, "unable to load chunk, err: %d", err);
 	}
 	return 0;
 }
@@ -109,10 +109,10 @@ int dump_chunk (lua_State *L) {
 	luaL_checktype(L, -1, LUA_TFUNCTION);
 	lua_settop(L, -1);
 	luaL_buffinit(L,&b);
-	int errno;
-	errno = lua_dump(L, writer, &b);
-	if (errno != 0){
-	return luaL_error(L, "unable to dump given function, errno:%d", errno);
+	int err;
+	err = lua_dump(L, writer, &b);
+	if (err != 0){
+	return luaL_error(L, "unable to dump given function, err:%d", err);
 	}
 	luaL_pushresult(&b);
 	return 0;
@@ -226,5 +226,5 @@ func (L *State) RawSeti(index int, n int) {
 
 // lua_gc
 func (L *State) GC(what, data int) int {
-    return int(C.lua_gc(L.s, C.int(what), C.int(data)))
+	return int(C.lua_gc(L.s, C.int(what), C.int(data)))
 }

--- a/lua/golua_c_lua53.go
+++ b/lua/golua_c_lua53.go
@@ -41,10 +41,10 @@ int load_chunk(lua_State *L, char *b, int size, const char* chunk_name) {
 	chunk ck;
 	ck.buffer = b;
 	ck.size = size;
-	int errno;
-	errno = lua_load(L, reader, &ck, chunk_name, NULL);
-	if (errno != 0) {
-		return luaL_error(L, "unable to load chunk, errno: %d", errno);
+	int err;
+	err = lua_load(L, reader, &ck, chunk_name, NULL);
+	if (err != 0) {
+		return luaL_error(L, "unable to load chunk, err: %d", err);
 	}
 	return 0;
 }
@@ -109,10 +109,10 @@ int dump_chunk (lua_State *L) {
 	luaL_checktype(L, -1, LUA_TFUNCTION);
 	lua_settop(L, -1);
 	luaL_buffinit(L,&b);
-	int errno;
-	errno = lua_dump(L, writer, &b, 0);
-	if (errno != 0){
-	return luaL_error(L, "unable to dump given function, errno:%d", errno);
+	int err;
+	err = lua_dump(L, writer, &b, 0);
+	if (err != 0){
+	return luaL_error(L, "unable to dump given function, err:%d", err);
 	}
 	luaL_pushresult(&b);
 	return 0;
@@ -228,5 +228,5 @@ func (L *State) RawSeti(index int, n int) {
 
 // lua_gc
 func (L *State) GC(what, data int) int {
-    return int(C.lua_gc(L.s, C.int(what), C.int(data)))
+	return int(C.lua_gc(L.s, C.int(what), C.int(data)))
 }

--- a/lua/golua_c_lua54.go
+++ b/lua/golua_c_lua54.go
@@ -49,10 +49,10 @@ int load_chunk(lua_State *L, char *b, int size, const char* chunk_name) {
 	chunk ck;
 	ck.buffer = b;
 	ck.size = size;
-	int errno;
-	errno = lua_load(L, reader, &ck, chunk_name, NULL);
-	if (errno != 0) {
-		return luaL_error(L, "unable to load chunk, errno: %d", errno);
+	int err;
+	err = lua_load(L, reader, &ck, chunk_name, NULL);
+	if (err != 0) {
+		return luaL_error(L, "unable to load chunk, err: %d", err);
 	}
 	return 0;
 }
@@ -111,10 +111,10 @@ int dump_chunk (lua_State *L) {
 	luaL_checktype(L, -1, LUA_TFUNCTION);
 	lua_settop(L, -1);
 	luaL_buffinit(L,&b);
-	int errno;
-	errno = lua_dump(L, writer, &b, 0);
-	if (errno != 0){
-	return luaL_error(L, "unable to dump given function, errno:%d", errno);
+	int err;
+	err = lua_dump(L, writer, &b, 0);
+	if (err != 0){
+	return luaL_error(L, "unable to dump given function, err:%d", err);
 	}
 	luaL_pushresult(&b);
 	return 0;
@@ -225,5 +225,5 @@ func (L *State) RawSeti(index int, n int) {
 
 // lua_gc
 func (L *State) GC(what, data int) int {
-    return int(C.lua_gc_compat(L.s, C.int(what), C.int(data)))
+	return int(C.lua_gc_compat(L.s, C.int(what), C.int(data)))
 }


### PR DESCRIPTION
Avoid warnings like this from the C  compiler:

```
 warning: '_errno' redeclared without dllimport attribute: previous dllimport ignored [-Wattributes]
  int errno;
      ^~~~~
```