### PR TITLE
Fix build tags for luajit and lua54

### DIFF
--- a/lua/lua.go
+++ b/lua/lua.go
@@ -13,7 +13,7 @@ package lua
 #cgo llua LDFLAGS: -llua
 
 #cgo luaa LDFLAGS: -llua -lm -ldl
-#cgo luajit LDFLAGS: -lluajit-5.1
+#cgo luajit LDFLAGS: -lluajit
 #cgo lluadash5.1 LDFLAGS: -llua-5.1
 
 #cgo linux,!lua52,!lua53,!lua54,!llua,!luaa,!luajit,!lluadash5.1 LDFLAGS: -llua5.1

--- a/lua/lua.go
+++ b/lua/lua.go
@@ -24,7 +24,7 @@ package lua
 #cgo darwin,!lua52,!lua53,!lua54,!llua,!luaa,!luajit,!lluadash5.1 pkg-config: lua5.1
 #cgo darwin,lua52,!llua,!luaa,!luajit,!lluadash5.1 pkg-config: lua5.2
 #cgo darwin,lua53,!llua,!luaa,!luajit,!lluadash5.1 pkg-config: lua5.3
-#cgo darwin,lua54,!llua,!luaa,!luajit,!lluadash5.1 pkg-config: lua5.4 m
+#cgo darwin,lua54,!llua,!luaa,!luajit,!lluadash5.1 pkg-config: lua5.4 -lm
 
 #cgo freebsd,!lua52,!lua53,!lua54,!llua,!luaa,!luajit,!lluadash5.1 LDFLAGS: -llua-5.1
 #cgo freebsd,lua52,!llua,!luaa,!luajit,!lluadash5.1 LDFLAGS: -llua-5.2


### PR DESCRIPTION
Hello,

i noticed that the build tag configurations contained minor typos which broke the build for luajit and lua54. 

- luajit was luajit-5.1
- lua54 resulted on macOS in a lua5.4 and a m requirement

Maybe i am wrong though, then just close this PR.

Thanks for the great work with the package! Just wanted to contribute my 2 cents.