### PR TITLE
Add helper function to easily create lua libraries

### DIFF
--- a/_example/library.go
+++ b/_example/library.go
@@ -7,13 +7,20 @@ func test(L *lua.State) int {
 	return 0
 }
 
+func test2(L *lua.State) int {
+	println("world!")
+	return 0
+}
+
 var funcs = map[string]lua.LuaGoFunction{
 	"test": test,
+	"test2": test2,
 }
 
 const code = `
 	local example = require("example")
 	example.test()
+	example.test2()
 	`
 
 func main() {

--- a/_example/library.go
+++ b/_example/library.go
@@ -1,0 +1,29 @@
+package main
+
+import "github.com/aarzilli/golua/lua"
+
+func test(L *lua.State) int {
+	println("hello!")
+	return 0
+}
+
+var funcs = map[string]lua.LuaGoFunction{
+	"test": test,
+}
+
+const code = `
+	local example = require("example")
+	example.test()
+	`
+
+func main() {
+	L := lua.NewState()
+	defer L.Close()
+	L.OpenLibs()
+	
+	L.RegisterLib("example", funcs)
+
+	if err := L.DoString(code); err != nil {
+		panic(err)
+	}
+}

--- a/lua/lua.go
+++ b/lua/lua.go
@@ -438,6 +438,21 @@ func (L *State) Register(name string, f LuaGoFunction) {
 	L.SetGlobal(name)
 }
 
+// Registers a map of go functions as a library that can be accessed using "require("name")"
+func (L *State) RegisterLib(name string, funcs map[string]LuaGoFunction) {
+	L.NewTable()
+	for fname, f := range funcs {
+		L.PushGoFunction(f)
+		L.SetField(-2, fname)
+	}
+
+	L.GetGlobal("package")
+	L.GetField(-1, "loaded")
+	L.PushValue(-3)
+	L.SetField(-2, name)
+	L.Pop(2)
+} 
+
 // lua_setallocf
 func (L *State) SetAllocf(f Alloc) {
 	L.allocfn = &f


### PR DESCRIPTION
Adds the `RegisterLib(name, funcs)` function to `lua.go`

This function allows for the simple and straight forward registration of libraries created from go, allowing for the following:
```lua
local example = require("example")
example.test()
```
Using lua libraries over the standard `Register(name, func)` has the advantage that script writers no longer have to deal with the annoyance of undefined global variables. I have also added an example to demonstrate the use of this new function.

Please let me know if you would like any changes, and thanks for maintaining this wonderful project.
Cheers!