### PR TITLE
Add ability to create lua states with context

### DIFF
--- a/lua/golua.go
+++ b/lua/golua.go
@@ -13,6 +13,7 @@ package lua
 import "C"
 
 import (
+	"context"
 	"reflect"
 	"sync"
 	"unsafe"
@@ -50,6 +51,8 @@ type State struct {
 
 	// User defined hook function
 	hookFn HookFunction
+
+	ctx context.Context
 }
 
 var goStates map[uintptr]*State

--- a/lua/golua.go
+++ b/lua/golua.go
@@ -52,7 +52,7 @@ type State struct {
 	// User defined hook function
 	hookFn HookFunction
 
-	ctx *context.Context
+	ctx context.Context
 }
 
 var goStates map[uintptr]*State

--- a/lua/golua.go
+++ b/lua/golua.go
@@ -52,7 +52,7 @@ type State struct {
 	// User defined hook function
 	hookFn HookFunction
 
-	ctx context.Context
+	ctx *context.Context
 }
 
 var goStates map[uintptr]*State

--- a/lua/lauxlib.go
+++ b/lua/lauxlib.go
@@ -197,12 +197,12 @@ func NewState() *State {
 
 func NewStateWithContext(ctx context.Context) *State {
 	L := NewState()
-	L.ctx = ctx
+	L.ctx = &ctx
 	return L
 }
 
 func (L *State) Context() context.Context {
-	return L.ctx
+	return *L.ctx
 }
 
 // luaL_openlibs

--- a/lua/lauxlib.go
+++ b/lua/lauxlib.go
@@ -6,7 +6,10 @@ package lua
 //#include <stdlib.h>
 //#include "golua.h"
 import "C"
-import "unsafe"
+import (
+	"context"
+	"unsafe"
+)
 
 type LuaError struct {
 	code       int
@@ -190,6 +193,16 @@ func NewState() *State {
 	}
 	L := newState(ls)
 	return L
+}
+
+func NewStateWithContext(ctx context.Context) *State {
+	L := NewState()
+	L.ctx = ctx
+	return L
+}
+
+func (L *State) Context() context.Context {
+	return L.ctx
 }
 
 // luaL_openlibs

--- a/lua/lauxlib.go
+++ b/lua/lauxlib.go
@@ -197,12 +197,12 @@ func NewState() *State {
 
 func NewStateWithContext(ctx context.Context) *State {
 	L := NewState()
-	L.ctx = &ctx
+	L.ctx = ctx
 	return L
 }
 
 func (L *State) Context() context.Context {
-	return *L.ctx
+	return L.ctx
 }
 
 // luaL_openlibs

--- a/lua/lua.go
+++ b/lua/lua.go
@@ -59,7 +59,7 @@ type LuaStackEntry struct {
 }
 
 func newState(L *C.lua_State) *State {
-	newstate := &State{L, 0, make([]interface{}, 0, 8), make([]uint, 0, 8), nil, nil}
+	newstate := &State{L, 0, make([]interface{}, 0, 8), make([]uint, 0, 8), nil, nil, nil}
 	registerGoState(newstate)
 	C.clua_setgostate(L, C.size_t(newstate.Index))
 	C.clua_initstate(L)
@@ -354,7 +354,7 @@ func (L *State) NewThread() *State {
 	//TODO: should have same lists as parent
 	//		but may complicate gc
 	s := C.lua_newthread(L.s)
-	return &State{s, 0, nil, nil, nil, nil}
+	return &State{s, 0, nil, nil, nil, nil, nil}
 }
 
 // lua_next


### PR DESCRIPTION
This Pr adds the `NewStateWithContext(ctx)` and  `Context()` functions, allowing the developer to easily pass program state around. As an example:

```golang
func test(L *lua.State) int {
        program_state := L.Context().Value(key).(some_struct)
	println(program_state.IsRunning())
	return 0
}
```