### PR TITLE
Feat: Add PushGoClosureWithUpvalues

### DIFF
--- a/_example/alloc.go
+++ b/_example/alloc.go
@@ -1,14 +1,16 @@
 package main
 
-import "github.com/aarzilli/golua/lua"
-import "unsafe"
-import "fmt"
+import (
+	"github.com/aarzilli/golua/lua"
+	"unsafe"
+	"fmt"
+)
 
 var refHolder = map[unsafe.Pointer][]byte{}
 
-//a terrible allocator!
-//meant to be illustrative of the mechanics,
-//not usable as an actual implementation
+// a terrible allocator!
+// meant to be illustrative of the mechanics,
+// not usable as an actual implementation
 func AllocatorF(ptr unsafe.Pointer, osize uint, nsize uint) unsafe.Pointer {
 	if nsize == 0 {
 		if _, ok := refHolder[ptr]; ok {
@@ -27,7 +29,7 @@ func AllocatorF(ptr unsafe.Pointer, osize uint, nsize uint) unsafe.Pointer {
 		ptr = unsafe.Pointer(&(slice[0]))
 		refHolder[ptr] = slice
 	}
-	//fmt.Println("in allocf");
+	// fmt.Println("in allocf");
 	return ptr
 }
 
@@ -36,8 +38,7 @@ func A2(ptr unsafe.Pointer, osize uint, nsize uint) unsafe.Pointer {
 }
 
 func main() {
-
-	//refHolder = make([][]byte,0,500);
+	// refHolder = make([][]byte,0,500);
 
 	L := lua.NewStateAlloc(AllocatorF)
 	defer L.Close()

--- a/_example/basic.go
+++ b/_example/basic.go
@@ -1,7 +1,9 @@
 package main
 
-import "github.com/aarzilli/golua/lua"
-import "fmt"
+import (
+	"github.com/aarzilli/golua/lua"
+	"fmt"
+)
 
 func test(L *lua.State) int {
 	fmt.Println("hello world! from go!")

--- a/_example/error.go
+++ b/_example/error.go
@@ -1,9 +1,11 @@
 package main
 
-import "github.com/aarzilli/golua/lua"
-import "fmt"
-import "errors"
-import "os"
+import (
+	"github.com/aarzilli/golua/lua"
+	"fmt"
+	"errors"
+	"os"
+)
 
 func testDefault(L *lua.State) {
 	err := L.DoString("print(\"Unknown variable\" .. x)")

--- a/_example/library.go
+++ b/_example/library.go
@@ -13,7 +13,7 @@ func test2(L *lua.State) int {
 }
 
 var funcs = map[string]lua.LuaGoFunction{
-	"test": test,
+	"test":  test,
 	"test2": test2,
 }
 
@@ -27,7 +27,7 @@ func main() {
 	L := lua.NewState()
 	defer L.Close()
 	L.OpenLibs()
-	
+
 	L.RegisterLibrary("example", funcs)
 
 	if err := L.DoString(code); err != nil {

--- a/_example/panic.go
+++ b/_example/panic.go
@@ -1,7 +1,9 @@
 package main
 
-import "github.com/aarzilli/golua/lua"
-import "fmt"
+import (
+	"github.com/aarzilli/golua/lua"
+	"fmt"
+)
 
 func test(L *lua.State) int {
 	fmt.Println("hello world! from go!")
@@ -9,7 +11,6 @@ func test(L *lua.State) int {
 }
 
 func main() {
-
 	var L *lua.State
 
 	L = lua.NewState()
@@ -29,7 +30,7 @@ func main() {
 
 	L.AtPanic(newPanic)
 
-	//force a panic
+	// force a panic
 	L.PushNil()
 	L.Call(0, 0)
 

--- a/_example/userdata.go
+++ b/_example/userdata.go
@@ -1,8 +1,10 @@
 package main
 
-import "github.com/aarzilli/golua/lua"
-import "unsafe"
-import "fmt"
+import (
+	"github.com/aarzilli/golua/lua"
+	"unsafe"
+	"fmt"
+)
 
 type Userdata struct {
 	a, b int

--- a/lua/c-golua.c
+++ b/lua/c-golua.c
@@ -117,9 +117,9 @@ static int callback_c (lua_State* L)
 	return golua_callgofunction(gostateindex,fid);
 }
 
-void clua_pushcallback(lua_State* L)
+void clua_pushcallback(lua_State* L, unsigned int nup)
 {
-	lua_pushcclosure(L,callback_c,1);
+	lua_pushcclosure(L,callback_c, 1 + nup);
 }
 
 void clua_pushgostruct(lua_State* L, unsigned int iid)

--- a/lua/dummy.go
+++ b/lua/dummy.go
@@ -1,3 +1,4 @@
+//go:build dummy
 // +build dummy
 
 // This file is part of a workaround for `go mod vendor` which won't

--- a/lua/golua.go
+++ b/lua/golua.go
@@ -32,6 +32,7 @@ type HookFunction func(L *State)
 const ExecutionQuantumExceeded = "Lua execution quantum exceeded"
 
 // Wrapper to keep cgo from complaining about incomplete ptr type
+//
 //export State
 type State struct {
 	// Wrapped lua_State object
@@ -55,8 +56,10 @@ type State struct {
 	ctx context.Context
 }
 
-var goStates map[uintptr]*State
-var goStatesMutex sync.Mutex
+var (
+	goStates      map[uintptr]*State
+	goStatesMutex sync.Mutex
+)
 
 func init() {
 	goStates = make(map[uintptr]*State, 16)

--- a/lua/golua.h
+++ b/lua/golua.h
@@ -10,7 +10,7 @@ void clua_hide_pcall(lua_State *L);
 
 unsigned int clua_togofunction(lua_State* L, int index);
 unsigned int clua_togostruct(lua_State *L, int index);
-void clua_pushcallback(lua_State* L);
+void clua_pushcallback(lua_State* L, unsigned int nup);
 void clua_pushgofunction(lua_State* L, unsigned int fid);
 void clua_pushgostruct(lua_State *L, unsigned int fid);
 void clua_setgostate(lua_State* L, size_t gostateindex);

--- a/lua/golua_c_lua51.go
+++ b/lua/golua_c_lua51.go
@@ -1,4 +1,5 @@
-//+build !lua52,!lua53,!lua54
+//go:build !lua52 && !lua53 && !lua54
+// +build !lua52,!lua53,!lua54
 
 package lua
 

--- a/lua/golua_c_lua52.go
+++ b/lua/golua_c_lua52.go
@@ -1,4 +1,5 @@
-//+build lua52
+//go:build lua52
+// +build lua52
 
 package lua
 

--- a/lua/golua_c_lua53.go
+++ b/lua/golua_c_lua53.go
@@ -1,4 +1,5 @@
-//+build lua53
+//go:build lua53
+// +build lua53
 
 package lua
 

--- a/lua/golua_c_lua54.go
+++ b/lua/golua_c_lua54.go
@@ -1,4 +1,5 @@
-//+build lua54
+//go:build lua54
+// +build lua54
 
 package lua
 

--- a/lua/lauxlib.go
+++ b/lua/lauxlib.go
@@ -6,6 +6,7 @@ package lua
 //#include <stdlib.h>
 //#include "golua.h"
 import "C"
+
 import (
 	"context"
 	"unsafe"
@@ -78,7 +79,7 @@ func (L *State) CheckString(narg int) string {
 //
 // BUG(everyone_involved): not implemented
 func (L *State) CheckOption(narg int, def string, lst []string) int {
-	//TODO: complication: lst conversion to const char* lst[] from string slice
+	// TODO: complication: lst conversion to const char* lst[] from string slice
 	return 0
 }
 

--- a/lua/lua51/dummy.go
+++ b/lua/lua51/dummy.go
@@ -1,3 +1,4 @@
+//go:build dummy
 // +build dummy
 
 // Package lua contains only a C header files.

--- a/lua/lua52/dummy.go
+++ b/lua/lua52/dummy.go
@@ -1,3 +1,4 @@
+//go:build dummy
 // +build dummy
 
 // Package lua contains only a C header files.

--- a/lua/lua53/dummy.go
+++ b/lua/lua53/dummy.go
@@ -1,3 +1,4 @@
+//go:build dummy
 // +build dummy
 
 // Package lua contains only a C header files.

--- a/lua/lua54/dummy.go
+++ b/lua/lua54/dummy.go
@@ -1,3 +1,4 @@
+//go:build dummy
 // +build dummy
 
 // Package lua contains only a C header files.

--- a/lua/lua_defs_lua51.go
+++ b/lua/lua_defs_lua51.go
@@ -1,4 +1,5 @@
-//+build !lua52,!lua53,!lua54
+//go:build !lua52 && !lua53 && !lua54
+// +build !lua52,!lua53,!lua54
 
 package lua
 

--- a/lua/lua_defs_lua52.go
+++ b/lua/lua_defs_lua52.go
@@ -1,4 +1,5 @@
-//+build lua52
+//go:build lua52
+// +build lua52
 
 package lua
 

--- a/lua/lua_defs_lua53.go
+++ b/lua/lua_defs_lua53.go
@@ -1,4 +1,5 @@
-//+build lua53
+//go:build lua53
+// +build lua53
 
 package lua
 

--- a/lua/lua_defs_lua54.go
+++ b/lua/lua_defs_lua54.go
@@ -1,4 +1,5 @@
-//+build lua54
+//go:build lua54
+// +build lua54
 
 package lua
 

--- a/lua/lua_test.go
+++ b/lua/lua_test.go
@@ -130,7 +130,6 @@ func TestCall(t *testing.T) {
 	L.PushString("Argument2")
 	L.PushString("Argument3")
 	err := L.Call(3, 2)
-
 	if err != nil {
 		t.Fatalf("Error executing call: %v\n", err)
 	}


### PR DESCRIPTION
Adds `PushGoClosureWithUpvalues` function on `State` that allows the user to provide extra upvalues besides the function upvalue on the closure.

The user just needs to keep in mind that the upvalues provided by them will start at index 2.

Also instead of fighting with gofumpt, I just ran it on the codebase and committed it separately. Feel free to remove that if unwanted.

Example from the included test
```go
	L := NewState()
	defer L.Close()

	closure := func(L *State) int {
		if !L.IsString(L.UpvalueIndex(2)) {
			t.Fatalf("upvalue 2 not set correctly, expected it to be a string")
		}
		if !L.IsNumber(L.UpvalueIndex(3)) {
			t.Fatalf("upvalue 3 not set correctly, expected it to be an number")
		}
		if L.ToString(L.UpvalueIndex(2)) != "Hello" {
			t.Fatalf("upvalue 2 not set correctly, expected it to equal \"Hello\"")
		}
		if L.ToInteger(L.UpvalueIndex(3)) != 15 {
			t.Fatalf("upvalue 3 not set correctly, expected it to equal 15")
		}
		return 0
	}

	L.PushString("Hello")
	L.PushInteger(15)
	L.PushGoClosureWithUpvalues(closure, 2)
	err := L.Call(0, 0)
	if err != nil {
		t.Fatalf("Call to function returned by PushGoClosureWithUpvalues should not fail: %s\n", err.Error())
	}
```