### PR TITLE
Fix C.lua_tointeger returning C.integer in some compilers

### DIFF
--- a/lua/golua_c_lua51.go
+++ b/lua/golua_c_lua51.go
@@ -112,7 +112,7 @@ import "C"
 import "unsafe"
 
 func luaToInteger(s *C.lua_State, n C.int) C.long {
-	return C.lua_tointeger(s, n)
+	return C.long(C.lua_tointeger(s, n))
 }
 
 func luaToNumber(s *C.lua_State, n C.int) C.double {


### PR DESCRIPTION
On Windows when I tried using golua with luajit, I received an error message while compiling with 

```
x86_64-w64-mingw32-gcc
clang version 11.0.0
```
ERROR:
```
github.com\aarzilli\golua@v0.0.0-20241229084300-cd31ab23902e\
lua\golua_c_lua51.go:115:9: cannot use func() _Ctype_lua_Integer {…}() 
(value of type _Ctype_lua_Integer) as _Ctype_long value in return statement
```

After I added the explicit cast the build was successful.